### PR TITLE
use hash of complete credentials (instead of just username) when cach…

### DIFF
--- a/lib/Whalerator/DockerClient/DockerClientBase.cs
+++ b/lib/Whalerator/DockerClient/DockerClientBase.cs
@@ -41,7 +41,7 @@ namespace Whalerator.DockerClient
         protected readonly IAuthHandler AuthHandler;
         public string Host { get; set; }
 
-        protected string CatalogKey() => $"{(AuthHandler.AnonymousMode ? "anon" : AuthHandler.RegistryCredentials.Username)}:{Host}:catalog";
+        protected string CatalogKey() => $"{(AuthHandler.AnonymousMode ? "anon" : AuthHandler.RegistryCredentials.GetCredentialHash())}:{Host}:catalog";
 
         protected string RepoTagsKey(string repository) => $"{Host}:repository:{repository}:tags";
         protected string RepoTagDigestKey(string repository, string tag) => $"{Host}:repository:{repository}:{tag}";

--- a/lib/Whalerator/ExtensionMethods.cs
+++ b/lib/Whalerator/ExtensionMethods.cs
@@ -21,6 +21,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Text;
 using System.Linq;
+using System.Text.Unicode;
 using Whalerator.Client;
 using Whalerator.Model;
 using Microsoft.Extensions.Logging;
@@ -34,6 +35,18 @@ namespace Whalerator
         public static void LogError(this ILogger logger, string message, Exception ex)
             => Microsoft.Extensions.Logging.LoggerExtensions.LogError(logger, ex, message);
 
+        /// <summary>
+        /// Hash a credential object, including username, password, and target regsitry
+        /// </summary>
+        /// <param name="credentials"></param>
+        /// <returns></returns>
+        public static string GetCredentialHash(this RegistryCredentials credentials)
+        {
+            var uidBytes = Encoding.UTF8.GetBytes(credentials.Username + credentials.Password + credentials.Registry);
+            var hash = System.Security.Cryptography.SHA256.Create().ComputeHash(uidBytes);
+            return Convert.ToBase64String(hash);
+        }
+        
         /*
         public static Permissions GetPermissions(this IAuthHandler handler, string repository)
         {


### PR DESCRIPTION
fixes scenario where multiple real users share a single psuedo-username with complex passwords