### PR TITLE
fixes 'fake template' values for security messaging

### DIFF
--- a/compose/complete/clair-config.yaml
+++ b/compose/complete/clair-config.yaml
@@ -2,7 +2,7 @@ clair:
   database:
     type: pgsql
     options:
-      source: host=pgsql port=5432 user=postgres password=abc123 sslmode=disable statement_timeout=60000
+      source: host=pgsql port=5432 user=postgres password=$secret.pgpassword sslmode=disable statement_timeout=60000
       cachesize: 16384
       paginationkey: 
   api:

--- a/compose/complete/docker-compose.yml
+++ b/compose/complete/docker-compose.yml
@@ -7,7 +7,7 @@ services:
   pgsql:
     image: postgres:11.2
     environment:
-    - POSTGRES_PASSWORD=abc123
+    - POSTGRES_PASSWORD=$secret.pgpassword
   redis:
     image: redis
   clair:

--- a/compose/devenv/clair-config.yaml
+++ b/compose/devenv/clair-config.yaml
@@ -2,7 +2,7 @@ clair:
   database:
     type: pgsql
     options:
-      source: host=pgsql port=5432 user=postgres password=abc123 sslmode=disable statement_timeout=60000
+      source: host=pgsql port=5432 user=postgres password=$secret.pgpassword sslmode=disable statement_timeout=60000
       cachesize: 16384
       paginationkey: 
   api:

--- a/compose/devenv/docker-compose.yml
+++ b/compose/devenv/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     ports: 
     - "5432:5432"
     environment:
-    - POSTGRES_PASSWORD=abc123
+    - POSTGRES_PASSWORD=$secret.pgpassword
   redis:
     image: redis
     ports:

--- a/compose/dockerhub/clair-config.yaml
+++ b/compose/dockerhub/clair-config.yaml
@@ -2,7 +2,7 @@ clair:
   database:
     type: pgsql
     options:
-      source: host=pgsql port=5432 user=postgres password=abc123 sslmode=disable statement_timeout=60000
+      source: host=pgsql port=5432 user=postgres password=$secret.pgpassword sslmode=disable statement_timeout=60000
       cachesize: 16384
       paginationkey: 
   api:

--- a/compose/dockerhub/docker-compose.yml
+++ b/compose/dockerhub/docker-compose.yml
@@ -6,7 +6,7 @@ services:
   pgsql:
     image: postgres:11.2
     environment:
-    - POSTGRES_PASSWORD=abc123
+    - POSTGRES_PASSWORD=$secret.pgpassword
   redis:
     image: redis
   clair:


### PR DESCRIPTION
we had stand in 'fake' values in templates, designed to point users to where the might need to fill in values. 

Pentesting saw these and got spooked. I've updated these to be more clear that they are secret / argumented values.